### PR TITLE
[142] Add capstone page with overal structure and evaluation rules

### DIFF
--- a/docs/_docs/Starters Academy (LDSSA)/Capstone-Project.md
+++ b/docs/_docs/Starters Academy (LDSSA)/Capstone-Project.md
@@ -1,0 +1,118 @@
+---
+title: Capstone Project
+category: Starters Academy (LDSSA)
+order: 4
+---
+
+## Structure 
+
+The capstone project is a chance to put everything you've learned in practice. 
+The _Capstone_ must be completed individually and it is composed of two important work
+stages, each ending with the delivery of a report and an app. At the end of each stage
+there will be a comment round in the reports and a chance for the students to improve 
+them with the provided feedback. In between stages there is a test round for your app, 
+where real data will be sent to it. This data should be used by you for evaluation and 
+eventually retraining of your model.
+
+#### Stage 1 
+
+In the first part of the project, you will receive a **client briefing**
+containing the instructions to the problem you have to solve. This will
+ contain a problem description, the available data to solve it and a list 
+ of requests:
+ 
+ * Some analysis questions to find an answer to;
+ * A particular task to solve, by producing a model and serving it in a web app;
+ * Detailed instructions on the report to produce.
+
+All of which are to be delivered at the end of this stage.
+
+#### App trial round
+
+Close to the deadline for report 1 and the application, we will provide an interval where you can try out your app. This mean we'll use the procedure to be used on the actual test round to send dummy data to your app, so you can:
+
+1. check if it's working
+2. if not, debug why
+3. check it's performance (how many requests you were able to answer, for example)
+
+This means that ideally you should have your app ready by then. This is not mandatory, as it is not an evaluation moment, but it is definitely recommended.
+
+
+#### App Test round
+
+Once you deliver your app and the first report, it's game on! We'll start sending requests into your app, in two rounds:
+
+* First, we'll send requests that you should be able to make predictions for;
+* Second, we'll send updates with the ground truth so that you can use it for future usage.
+
+Don't worry if you don't understand right now what this will mean, you'll get there. All you need to know is that at this point you must deliver a working app, i. e., it should return some prediction for our data. 
+
+
+#### Stage 2
+
+In the second part of the project, you will analyse the real data you received and produce a second report going through it, retraining your model and redeploying it. 
+
+At the end of this you will produce a second report and will have a smaller app test round. Redeploying your model is not mandatory, but recommended to show improvements in your results.
+
+
+#### Comment rounds
+
+In each stage you produce a version of the report. This is an opportunity for you to receive feedback and improve your reports.
+
+* There is only 1 comment round per report;
+* There is a deadline to do changes after the comments are released - refer to the calendar below;
+* Information about pass/fail is not mentioned by instructors;
+* Disambiguation should not be expected as a standard, i.e., you may ask a question in the comments that gets no answer, but can be provided by instructors if they deem it necessary;
+* You can make changes that were not requested in the comments; however, instructors will be looking for things that they did mention.
+
+
+### Time commitment
+You should be prepared to spend a recommended *10 to 20 hours per week* on the capstone, especially in its first 3 weeks.
+
+
+### Capstone Evaluation Rules
+
+In order to pass the capstone all the following must be delivered and pass a set of standards:
+
+* Report 1;
+* Working API;
+* Report 2;
+* All code (API + training + analysis).
+
+#### API
+
+All students should have delivered a working API by report 1 to pass. This will be verified by the following:
+
+* the API responds to the requests - anything other than a 404;
+* an intermediate delivery of the app code may be requested for confirmation.
+
+
+#### Report
+
+In order to get a passing chance, both reports need to be sent with **all sections**. In addition, each section has to pass a minimum threshold of quality, with respect to the requirements presented. You can refer to the [sections and descriptions of batch 4](TBD) to understand better how these may look.
+
+#### Automatic fails
+
+The capstone will automatically be considered a fail if:
+
+* Empty section;
+* Section with 1 or 2 sentences;
+* Section with bullet points/table but no actual explanatory text;
+* No API built is a fail.
+
+
+
+### Calendar
+
+Description |  Date | 
+-------------|-------------|
+Kick off |  17th January 2022 | 
+Trial round of requests |  4th or 5th February 2022 |  
+Deadline report 1 and app launched |  6th February 2022, 23h59 UTC  |
+First round of requests  |  7th February 2022 at 00h01UTC to 14th February 2022 at 23h59 UTC  |
+Comments to report 1 made by instructors  |  14th February 2022 23h59 UTC  |
+Deadline report 2 + redeploy + address comments to report 1 |  6th March 2022, 23h59 UTC  |
+Second round of requests |  7th March 2022 at 00h01UTC to 14th March 2022 at 23h59 UTC  |
+Comments to report 2 made by instructors  |  13th March 2022, 23h59 UTC  |
+Deadline address comments to report 2  |  20th March 2022, 23h59 UTC  |
+Graduates announced  |  31st March 2022  |

--- a/docs/_docs/Starters Academy (LDSSA)/FAQ.md
+++ b/docs/_docs/Starters Academy (LDSSA)/FAQ.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 category: Starters Academy (LDSSA)
-order: 4
+order: 6
 ---
 
 > ⚠️ Some information in this page might be outdated.


### PR DESCRIPTION
Current status of page for those who want to get the visual feel:


![Screenshot 2021-05-05 at 16 43 37](https://user-images.githubusercontent.com/11612892/117169932-75b4ab00-adc1-11eb-88cc-bfdb040d0fac.png)

![Screenshot 2021-05-05 at 16 43 58](https://user-images.githubusercontent.com/11612892/117169939-764d4180-adc1-11eb-8fe7-5684baf27db6.png)

![Screenshot 2021-05-05 at 16 44 01](https://user-images.githubusercontent.com/11612892/117169945-78af9b80-adc1-11eb-92bb-af7d18908265.png)

Closes #142 
Closes #138 
Closes #141 