### PR TITLE
incorporate charter into organization page as per #159

### DIFF
--- a/docs/_docs/About us/LDSA-Areas-of-Responsibility.md
+++ b/docs/_docs/About us/LDSA-Areas-of-Responsibility.md
@@ -157,7 +157,7 @@ effort is concentrated at the beginning of the batch with the bootcamp.
 
 ### Partnerships  
 [Primary enabler](../Member-Directory/#organizational-structure)  
-The Partnerships team should ensure that any relationship that we have with other companies or organizations stay healthy and are in line with the charter. You must also ensure that expectations for both organizations are in line and that it is a worthwhile experience. 
+The Partnerships team should ensure that any relationship that we have with other companies or organizations stay healthy and are in line with the [LDSA Charter](../Lisbon-Data-Science-Academy-(Organization)). You must also ensure that expectations for both organizations are in line and that it is a worthwhile experience. 
 
 Some specific tasks in this are are:  
 - When we are contacted by outside organizations, they receive a polite, warm, and professional greeting.

--- a/docs/_docs/About us/Lisbon-Data-Science-Academy-(Organization).md
+++ b/docs/_docs/About us/Lisbon-Data-Science-Academy-(Organization).md
@@ -4,37 +4,110 @@ category: About us
 order: 1
 ---
 
+*Last updated: August 2021*
+
+---
+
+## Founders and history
 
 The Lisbon Data Science Academy (_"The Academy"_ or _"LDSA"_) is a not-for-profit organization. 
 
-It was started in June 2017 by a group of [volunteers](#founders) who love data science. The organization runs the [Lisbon Data Science Starters Academy](../../Starters Academy (LDSSA)/01-Starters-Academy-(Course)/), a course for python programmers who wish to enter Data Science, and offers a [Data Science Prep Course](../../DS Prep Course/Data-Science-Prep-Course/).
+It was started in June 2017 by a group of [volunteers](#founders) who love data science. This organization currently runs the [Lisbon Data Science Starters Academy](../../Starters Academy (LDSSA)/01-Starters-Academy-(Course)/), a course for python programmers who wish to enter Data Science, and offers a [Data Science Prep Course](../../DS Prep Course/Data-Science-Prep-Course/).
 
-For a complete description of the Academy, read the [LDSA Charter](https://docs.google.com/document/d/1EDQF8lFZA0DYKhru57rxLI4d7s3ReiN90BFdjTHtP-Q/edit)  
+Sam Hopkins, Chi Dominguez, Pedro Fonseca and João Ascencão founded the Academy with the following goals: take people with basic understanding of the Python programming language and teach them the basics of data science (data cleaning and preparation, classification and regression and validation techniques), develop the Lisbon data science community and bring people interested in data science together, and fill the growing need for Data Scientists in industry.
 
-### Mission
-> _**To create and maintain a community of excellence with the teaching and learning of Data Science at its core.**_
+---
 
-### Key principles
-> **Independent**    - the Academy has volunteers from many companies and Academia, and is run only for Education 
-> **Collaborative**  - we volunteer our time at the Academy because we believe we can make a better world  
-> **Not for profit** - the Academy re-invests revenues back into students' education   
-> **Open-source**    - OS rocks!   
-> **Inclusive (hence open)** - no discrimination on gender, orientation, religion, color, or nationality   
-> **Geeky**          - we're all geeks, and happy about it   
+## Mission
 
-### Founders
+> __The Lisbon Data Science Academy exists to create and maintain a community of excellence, with the teaching and learning of Data Science at its core.__
 
-The founding members, responsible for setting up the organizing body are:
-* Sam Hopkins
-* Chi Dominguez
-* Pedro Fonseca
-* João Ascencão
+Let’s break down each part of the mission to explore what it means as well as it’s implications.
 
-### Main objectives 
+- “create and maintain a community”
+  - We are building a community and this is the first step. However, after it is built, our job is not done! Expanding and maintaining a engaged community is an ongoing process and we must continue to nurture our community even after the initial building is done. The decisions that we make in all steps of the creation process will be a part of the organization after it is “built”.
+- “community of excellence”
+  - Everything that the community does must be excellent. Every single person that is a part of the organization must be proud because the community is excellent per se. Through excellence in all areas, we will connect and develop relationships that will attract excellent people and expand the community while upholding its purpose. 
+  - Excellence does not mean exclusive and the creation of a community isn’t limited to Data Science. All needed talents are welcome to benefit our community, since there are many roles to be filled in order to create greatness. If you are not a Data Scientist but have excellent work and ideas to contribute, there is a place for you. that our Data Science community needs, you are more than welcome.
+  - Our commitment to excellence will also help guide us when things get hard. When faced with hard decisions that tempt us to choose the easiest solution - such making exceptions in learning units that fall below standards or graduating students that haven't invested as required - a commitment to excellence should make clear what the right thing to do is.
+- “with the teaching and learning of Data Science at its core”
+  - This is what everything else revolves around. This is what binds everyone in the community together is a commitment to teaching and learning about Data Science.
+  - Everyone in the community should strive to be both a teacher and student of Data Science. Just being a passive learner is not enough. A know-it-all that doesn’t think they have anything to learn either does not embrace this mission or does not understand that in our community we shall learn from the experience of others, through positive and constructive debate.
 
-* Taking people with basic understanding of the Python programming language and teaching them the basics of data science, including:
-   * Data cleaning and preparation
-   * Classification and Regression 
-   * Validation techniques 
-* Developing the Lisbon data science community, and bring people interested in data science together. 
-* Filling the growing need for Data Scientists in industry.
+## Values and Key Principles
+- Independent (not owned or influenced by any company)
+- Collaborative
+- Nonprofit
+- Open-source 
+- Inclusive (hence open)
+- Geeky
+
+## Organization Structure
+
+### The Assembly
+The assembly consists of all members and the main responsibility is to hold elections of the leadership structure every 2 years unless the Assembly General calls one sooner. The Assembly must also vote on yearly budgets. Both votes require a simple majority with 75% quorum.
+
+### Assembly Membership
+Since assembly membership includes the right to an equally-weighted vote, membership requirements will be based upon participation under the assumption that participation is what gives the required context to enable informed voting.
+
+In light of this, any person may become a member by:
+
+- Actively participating in at least one discussion per month for 3 months
+- Putting in 30 hours of work for the Academy in any capacity in the previous 6 months from the current time.
+- Requesting to become a member of the academy.
+
+## The Leadership
+The leadership structure is divided into 3 branches:
+
+- Assembly Admin
+- Finance
+- Executive
+
+Each of these branches contains a head and two secretaries. The responsibility of the head is to ensure that the duties of the branch are carried out. The secretaries are responsible to advise the head of their branch while assisting in execution of its duties. 
+
+### Assembly Admin
+It is the responsibility of the Assembly Admin to ensure that the leadership votes are held as well as presiding over the votes when they occur. It is the duty of the Assembly Admin to hold emergency leadership votes in the case they are petitioned to do so by a simple majority of the Assembly or at his or her pleasure. Leadership and budget votes must be announced 20 days in advance.
+
+### Finance
+The Finance branch is responsible for bringing a fiscally responsible and legal budget to the yearly vote of the Assembly. It must regularly review the expenditures and balance sheet of the Academy to ensure legal compliance of the yearly budget, activities which require expenditure of money, and treasurer. 
+
+### Executive
+The most important role of the executive is to ensure that they, the academy as a whole, and the individuals that make up are always acting in accordance with the mission, values, and key principles defined in this charter by providing clear and thoughtful leadership and guidance.
+
+The executive is responsible for appointing or removing the primary enablers of each area of responsibility by ⅔ majority. The executive must also create, remove, or modify the specification of areas of responsibility as new needs arise. In addition to this, it has final decision making power over all disputes in areas that are not already explicitly assigned to any other branch or role within the academy. The executive is responsible for ensuring that areas of responsibility are done according to specification.
+
+As per Portuguese law, one of the secretaries must be designated the Treasurer and this Treasurer may NOT serve as the head of the Finance branch.
+
+## Areas of Responsibility
+Areas of Responsibility (AOR) are the mechanism by which the Academy ensures that work can be distributed amongst members and completed with clear accountability and ownership. Each area of responsibility will have at the very least a description, primary responsibilities, and a primary enabler but may include more as the executive or primary enablers see fit.
+### AOR Description
+An AOR description is a subjective and short paragraph describing why it exists and the general type of problem it is supposed to solve.
+
+### AOR Primary Responsibilities
+This is a non-subjective and specific list of responsibilities that fall under this AORs purview. This should be a relatively small list of the most important things that have been identified as critical to the pursuit of the Academy’s mission. This list should not attempt to be exhaustive so as not to confuse tasks of minor import with those that are mission critical.
+
+### AOR Primary Enabler
+An AOR Primary Enabler is a single person who is responsible for ensuring that the duties of an AOR are executed. Note that this does not mean that this person must execute all of the duties themselves and the Primary Enabler is encouraged to recruit as needed in order to assist in creating a path to success for their AOR. 
+
+
+## Creation and Scheduling of Courses and Batches
+The mission outlined in this charter is quite broad and thus provides an enormous amount of flexibility in the pursuit of fulfilling it. However, the academy is and should be expected to create and deliver learning material in the form of courses which are to be grouped first by courses and then batches. We can take the Starters Academy as an example which is a course that is delivered in 6-month batches. 
+
+The responsibility to create, schedule, and deliver courses and batches is assigned to the 9 member leadership team. The creation of courses is done by proposing and ratifying a charter with a ⅔ majority. Any amendments to a course charter also requires a ⅔ majority amongst the Leadership. Scheduling of batches within the courses may be proposed by any member of the leadership and must be ratified by a ⅔ majority.
+
+## Community and Brand Management
+The teaching and learning portion of the mission is delegated to the creation of courses and batches but the community portion also needs to be directly addressed in this charter. The need for this arises from the need for continuity amongst the courses and batches. Although different courses have a different set of students, instructors, curricula, etc. they are all part of the same community of excellence.
+
+The executive may write and modify AOR Descriptions for Community and Brand managers and appoint Primary Enablers with a ⅔ majority. Note that this AOR is not at the course level as most of the others but rather at the level of the parent organization.
+
+## Reward Structures
+Since the Academy is volunteer-run and should only provide monetary compensation directly to individuals in extreme cases, it is left up to the course charter to decide how Academy funds may be used to reward the volunteers in a way that is consistent with the charter mission and the LDSA values.
+
+## Final Notes
+All members and the leadership team are expected to act on a good faith basis. It is expected that all matters that are brought to a vote are to be discussed in the appropriate forum before the vote occurs in order to provide and encourage a chance for healthy debate. 
+
+---
+
+_This page refers to the LDSA Charter as of August 2021 (original document [here](https://docs.google.com/document/d/1EDQF8lFZA0DYKhru57rxLI4d7s3ReiN90BFdjTHtP-Q/edit)). This document is to be held as supplementary material to the articles of incorporation and is mainly meant to define processes and organizational structure that changes more often than the articles of incorporation._
+
+---

--- a/docs/_docs/About us/Lisbon-Data-Science-Academy-(Organization).md
+++ b/docs/_docs/About us/Lisbon-Data-Science-Academy-(Organization).md
@@ -14,8 +14,6 @@ The Lisbon Data Science Academy (_"The Academy"_ or _"LDSA"_) is a not-for-profi
 
 It was started in June 2017 by a group of [volunteers](#founders) who love data science. This organization currently runs the [Lisbon Data Science Starters Academy](../../Starters Academy (LDSSA)/01-Starters-Academy-(Course)/), a course for python programmers who wish to enter Data Science, and offers a [Data Science Prep Course](../../DS Prep Course/Data-Science-Prep-Course/).
 
-Sam Hopkins, Chi Dominguez, Pedro Fonseca and João Ascencão founded the Academy with the following goals: take people with basic understanding of the Python programming language and teach them the basics of data science (data cleaning and preparation, classification and regression and validation techniques), develop the Lisbon data science community and bring people interested in data science together, and fill the growing need for Data Scientists in industry.
-
 ---
 
 ## Mission

--- a/docs/_docs/Starters Academy (LDSSA)/02-Target-audience-and-Pre-requisites-for-the-Starters-Academy.md
+++ b/docs/_docs/Starters Academy (LDSSA)/02-Target-audience-and-Pre-requisites-for-the-Starters-Academy.md
@@ -79,4 +79,4 @@ The Academy operates under a strict [Code of Conduct](../../About us/Code-of-Con
 
 ## Volunteering
 
-Check out the [Membership Types](https://docs.google.com/document/d/1kQSYyhxYkYIxTXOb2PbQF8qZfGikFzy_nypathWPJ5E/edit?usp=sharing) in the LDSSA charter doc to see what is available.
+Check out the Membership Types in the [LDSA Charter](../Lisbon-Data-Science-Academy-(Organization)) doc to see what is available.

--- a/docs/_docs/Volunteers/LDSA-Primary-Enabler-Agreement.md
+++ b/docs/_docs/Volunteers/LDSA-Primary-Enabler-Agreement.md
@@ -12,7 +12,7 @@ This agreement serves to set expectations from the side of the Academy as well a
 **I commit to 2 hours per week on average.** We’ve seen that there is a minimum of 3 hours of work, on average, needed to give an AOR everything it needs. Some weeks there will be no work, others you’ll spend 10 hours on, for example, an event. Plus, if you put in your time, you’ll integrate better into the team and get to know people.
 
 ## Commitment to the Mission and Values
-**I commit to knowing and acting in accordance with the mission and values** as defined in the [LDSA charter](https://docs.google.com/document/d/1EDQF8lFZA0DYKhru57rxLI4d7s3ReiN90BFdjTHtP-Q/). You are expected to know what the mission is and keep it in mind when making decisions. You are expected not to act in ways that are counter to the mission or our values.
+**I commit to knowing and acting in accordance with the mission and values** as defined in the [LDSA Charter](../Lisbon-Data-Science-Academy-(Organization)). You are expected to know what the mission is and keep it in mind when making decisions. You are expected not to act in ways that are counter to the mission or our values.
 
 ## Communication Commitment
 **I commit to communicating with the rest of the team.** If you’re struggling, that’s okay. These are not simple positions and the organization has a lot of members. It’s okay to struggle for a bit with something but if it goes on too long, it is your duty to seek help. Finally, if you become unable to hold the position you should communicate this, without shame, to a [member of the Executive Team](../../About us/Member-Directory#executive-team).


### PR DESCRIPTION
Hey I need your input on this update, which basically incorporates the LDSA Charter on the organization page in the Wiki, and also makes a sum-up of the history and founders of the LDSA.

I'd need at least a review from a founder to make sure the info is correct, and from a present executive team member to assert the current info on the page.

Thank you! 🙏 