### PR TITLE
Added temporary outdate warning on Prep Course page

### DIFF
--- a/docs/_docs/DS Prep Course/Data-Science-Prep-Course.md
+++ b/docs/_docs/DS Prep Course/Data-Science-Prep-Course.md
@@ -4,6 +4,8 @@ category: DS Prep Course
 order: 1
 ---
 
+> ## 🚧 This page is outdated. We will be updating it soon with info for Prep Course 2022.
+
 What's in this page:
 
 - [Course overview](#course-overview)


### PR DESCRIPTION
## Changelog

- This is a quick temporary fix just so that any user visiting the Prep Course page understands that the page is not yet updated, but will be soon, with info for Prep Course 2022.
- This warning shall be removed on PR for #336 @minhhoang1023 FYI