### PR TITLE
update calendar

### DIFF
--- a/docs/_docs/Applicants/Application-process.md
+++ b/docs/_docs/Applicants/Application-process.md
@@ -71,7 +71,7 @@ or at any time during the course, I will be expelled from the Academy.
 
 ## Application steps and important dates
 
-You can check the official calendar for Batch 5 [here](https://calendar.google.com/calendar/embed?src=c_2816k5gaulrl71urnrplhcmm9s%40group.calendar.google.com&ctz=Europe%2FLisbon).
+You can check the official calendar for Batch 6 [here](https://calendar.google.com/calendar/embed?src=c_jm13ojnma9kcfc3ehr22qvkq9c%40group.calendar.google.com&ctz=Europe%2FLisbon).
 
 
 | Activity                          | Date/Deadline                                    |
@@ -83,22 +83,22 @@ You can check the official calendar for Batch 5 [here](https://calendar.google.c
 | Payments & scholarship interviews | 2022-07-26 00h00 GMT+1 to 2022-07-31 23h59 GMT+1 |
 | Admissions closed                 | 2022-08-01 23h59 GMT+1                           |
 
-If you complete the signup in the portal and confirm your email address, you'll always receive an email with the outcome of your application. This email should be sent between the 5th and 12th July.
+If you complete the signup in the portal and confirm your email address, you'll always receive an email with the outcome of your application. This email should be sent between the 25th of July and 5th of August.
 
 
 ### Admission tests
 
-The coding test should take less than 3 hours to complete. You can do the test any time between 2020-06-21 and 
-2020-07-04, but once you start it you have to complete it within 3 hours (pausing it is not available). So, 
+The coding test should take less than 3 hours to complete. You can do the test any time between 2022-07-11 and 
+2022-07-24, but once you start it you have to complete it within 3 hours (pausing it is not available). So, 
 make sure that you block 3 hours of your time to work on this test.
 
 The Leaning Units about pandas will have two parts: learning and exercises. In the learning part, you'll learn 
 new concepts. In the exercises, we'll evaluate if you understood these new concepts. Only the exercises need to 
 be submitted and will be graded. There are no time constraints for the Learning Units: you can start them at any 
-time after 2020-06-21 and you can make pauses while working on them, as long as you submit them before 2020-07-04.
+time after 2022-07-11 and you can make pauses while working on them, as long as you submit them before 2022-07-24.
 
 The dates when you submit the coding test and the Learning Units don't have any influence on the selection 
-process, as long as it's before 2020-07-04. Finishing earlier doesn't give you any advantage, so take your time!
+process, as long as it's before 2022-07-24. Finishing earlier doesn't give you any advantage, so take your time!
 
 These are the main topics that will be evaluated on the coding test:
 - Programming in Python
@@ -126,7 +126,7 @@ not paid on time, we'll reject the candidate and give their seat to the next can
 
 This year, because of the Covid-19 crisis, we've kept the lowered fees from 2020/2021.
 
-For the 2021/2022 Starters Academy, the fees will be:
+For the 2022/2023 Starters Academy, the fees will be:
 
 - Student: 100€ (You'll need to present a valid student card at payment time)
 - Regular: 250€
@@ -163,7 +163,7 @@ This scheme illustrates the admissions process.
 ***
 
 
-_This is admissions process that will be followed in order to select the students for batch5 of the Lisbon 
+_This is admissions process that will be followed in order to select the students for batch 6 of the Lisbon 
 Data Science Starters Academy._
 
 _However, we reserve the right to make changes to this process in case of unforeseen events that harm our 

--- a/docs/_docs/Applicants/Application-process.md
+++ b/docs/_docs/Applicants/Application-process.md
@@ -74,15 +74,14 @@ or at any time during the course, I will be expelled from the Academy.
 You can check the official calendar for Batch 5 [here](https://calendar.google.com/calendar/embed?src=c_2816k5gaulrl71urnrplhcmm9s%40group.calendar.google.com&ctz=Europe%2FLisbon).
 
 
-| Activity |  Date/Deadline | 
-|--------|-------------|
-| Sign-up on the Admission Portal  |  2021-06-18 00h00 GMT+1 to 2021-06-20 23h59 GMT+1 | 
-| Scholarship applications  |  2021-06-18 00h00 GMT+1 to 2021-06-20 23h59 GMT+1 | 
-| Test & SLUs   |  2021-06-21 00h00 GMT+1 to 2021-07-04 23h59 GMT+1 | 
-| Candidate Selection | 2021-07-05  |
-| Payments & scholarship interviews | 2021-07-05 00h00 GMT+1 to 2021-07-11 23h59 GMT+1  |
-| Admissions closed | 2021-07-11 23h59 GMT+1  |
-| Introduction session | 2021-07-17 23h59 GMT+1  |
+| Activity                          | Date/Deadline                                    |
+|-----------------------------------|--------------------------------------------------|
+| Sign-up on the Admission Portal   | 2022-07-08 00h00 GMT+1 to 2022-07-10  23h59 GMT+1 |
+| Scholarship applications          | 2022-07-08 00h00 GMT+1 to 2022-07-10  23h59 GMT+1 |
+| Test & SLUs                       | 2022-07-11 00h00 GMT+1 to 2022-07-24 23h59 GMT+1 |
+| Candidate Selection               | 2022-07-25                                       |
+| Payments & scholarship interviews | 2022-07-26 00h00 GMT+1 to 2022-07-31 23h59 GMT+1 |
+| Admissions closed                 | 2022-08-01 23h59 GMT+1                           |
 
 If you complete the signup in the portal and confirm your email address, you'll always receive an email with the outcome of your application. This email should be sent between the 5th and 12th July.
 

--- a/docs/_docs/Applicants/Application-process.md
+++ b/docs/_docs/Applicants/Application-process.md
@@ -39,8 +39,8 @@ You can read more about it [here](https://github.com/LDSSA/forum/issues/1).
 
 All the candidates of the Starters Academy are expected to read, acknowledge and follow: 
 
-* Our [**Code of Conduct**](../../About us/Code-of-Conduct#application-to-the-academy);
-* Our [**Refund Policy**](../../Starters Academy (LDSSA)/07-Refund-Policy)
+* Our [**Code of Conduct**](https://ldssa.github.io/wiki/About%20us/Code-of-Conduct/);
+* Our [**Refund Policy**](https://ldssa.github.io/wiki/Starters%20Academy%20(LDSSA)/07-Refund-Policy/)
 * The time commitment described below
 
 This is one of the first steps in the admissions process.

--- a/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
+++ b/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
@@ -156,29 +156,33 @@ The _Capstone_ must be completed individually.
 
 The overal schedule and most important deadlines for batch 5 follow:
 
-| Activity |  Date/Deadline | 
-|--------|-------------|
-| Prep Work and admissions  |  June | 
-| Introduction session  |  17th July 2021 | 
-| Bootcamp   |  24th & 25th July 2021 | 
-| Bootcamp SLU deadlines  | 14th August 2021,  23h59 UTC  |
-| Hackathon 1   |  15th August 2021  | 
-| Spec 2 BLU deadlines  | 11th September 2021,  23h59 UTC  | 
-| Hackathon 2  | 12th September 2021  | 
-| Spec 3 BLU deadlines  | 9th October 2021,  23h59 UTC  | 
-| Hackathon 3  |  10th October 2021 |  
-| Spec 4  BLU deadlines  | 6th November ,  23h59 UTC  | 
-| Hackathon 4  | 7th November 2021  |  
-| Spec 5 BLU deadlines  | 4th December 2021,  23h59 UTC  |  
-| Hackathon 5  |   5th December 2021 |  
-| Spec 6 BLU deadlines  | 15th January 2022, 23h59 UTC  | 
-| Hackathon 6  |  16th January 2022 | 
-| Capstone Kick off  |  17th January 2022 |  
-| Capstone Deadline report 1 + app  |  6th February 2022, 23h59 UTC  |
-| Capstone Deadline report 2 + redeploy + address comments to report 1 |  6th March 2022, 23h59 UTC  |
-| Capstone Graduates announced  |  31st March 2022  |
+| Activity                                                             | Date/Deadline                  |
+|----------------------------------------------------------------------|--------------------------------|
+| Prep Work and admissions   |July 2022                           |
+| Batch 6 kick off                                             | 2022-09-19                          |
+| Introduction session                                                 | 2022-09-25                 |
+| Set-up                                                             | 2022-09-26 and 2022-09-30           |
+| Bootcamp                                                             | 2022-10-01 and 2022-10-02           |
+| Bootcamp SLU deadlines                                               | 2022-10-22, 23h59 UTC    |
+| Hackathon 1                                                          | 2022-10-23              |
+| Spec 2 BLU deadlines                                                 | 2022-11-19, 23h59 UTC |
+| Hackathon 2                                                          | 2022-11-20            |
+| Spec 3 BLU deadlines                                                 | 2022-12-17, 23h59 UTC    |
+| Hackathon 3                                                          | 2022-12-18              |
+| Spec 4 BLU deadlines                                                 | 2023-02-04 , 23h59 UTC       |
+| Hackathon 4                                                          |    2023-02-05           |
+| Spec 5 BLU deadlines                                                 |  2023-03-04, 23h59 UTC   |
+| Hackathon 5                                                          |    2023-03-05           |
+| Spec 6 BLU deadlines                                                 | 2023-04-01, 23h59 UTC   |
+| Hackathon 6                                                          |   2023-04-02          |
+| Capstone Kick off                                                    |     2023-04-03         |
+| Capstone Clarification email                                       |       2023-04-09       |
+| Capstone Deadline report 1 + app                                     |  2023-04-30 , 23h59 UTC   |
+| Capstone Round of requests                                     |  2023-05-01 to 2023-05-07 |
+| Capstone Deadline report 2 + redeploy + address comments to report 1 | 2023-05-28, 23h59 UTC      |
+| Capstone Graduates announced                                         |       2023-06-19         |
 
-The master schedule google calendar is [here](https://calendar.google.com/calendar/embed?src=c_2816k5gaulrl71urnrplhcmm9s%40group.calendar.google.com&ctz=Europe%2FLisbon)
+The master schedule google calendar is [here](https://calendar.google.com/calendar/embed?src=c_jm13ojnma9kcfc3ehr22qvkq9c%40group.calendar.google.com&ctz=Europe%2FLisbon)
  - you can add this calendar to most calendar apps so that you can be sure that you stay aware of all the important dates. 
 
 

--- a/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
+++ b/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
@@ -51,11 +51,11 @@ we will go over the following topics:
 
 ### Bootcamp Details
 
-The _Bootcamp_ is a 2-day event, on July 24th (Saturday) and 25th (Sunday). The first hackathon is 
-three weeks after the bootcamp, and will be held on August 15th (Sunday).
+The _Bootcamp_ is a 2-day event. The first hackathon is 
+three weeks after the bootcamp.
 
 During the _Bootcamp_ the students and teachers will participate virtually in a series of 
-presentation and exercises, about 10 hours per day, and the students will go through 16 _Small 
+presentation and exercises, about 10 hours per day, and the students will go through 14 _Small 
 Learning Units_. 
 
 Even though this is a remote edition, we expect everyone to be virtually present during the full 
@@ -69,13 +69,13 @@ Academy activities.**
 ### Specializations 
 Specializations are sets of _Learning Units_ and _Hackathons_, focusing on specific themes.
 
-The first specialization consists of:
+The **first** specialization consists of:
 - 3 SLUs that are covered during the admissions process (see [here](../../Applicants/Application-process#admission-tests))
 - 14 SLUs that are covered during the Bootcamp
 - 2 optional SLUs with extra content
 - Hackathon #1 about Binary Classification
 
-Each of the remaining 5 specializations consists of:
+Each of the **remaining 5 specializations** consists of:
 - 3 BLUs
 - 1 hackathon
 

--- a/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
+++ b/docs/_docs/Starters Academy (LDSSA)/01-Starters-Academy-(Course).md
@@ -154,26 +154,26 @@ The _Capstone_ must be completed individually.
 
 ## Schedule
 
-The overal schedule and most important deadlines for batch 5 follow:
+The overal schedule and most important deadlines for batch 6 follow:
 
-| Activity                                                             | Date/Deadline                  |
-|----------------------------------------------------------------------|--------------------------------|
-| Prep Work and admissions   |July 2022                           |
+| Activity  | Date/Deadline                  |
+|---------------------------------------------------------------------|--------------------------------|
+| Prep Work and admissions |July 2022 (see full calendar [here](https://ldssa.github.io/wiki/Applicants/Application-process/)) |
 | Batch 6 kick off                                             | 2022-09-19                          |
 | Introduction session                                                 | 2022-09-25                 |
 | Set-up                                                             | 2022-09-26 and 2022-09-30           |
 | Bootcamp                                                             | 2022-10-01 and 2022-10-02           |
-| Bootcamp SLU deadlines                                               | 2022-10-22, 23h59 UTC    |
+| Bootcamp SLUs submission deadline                                               | 2022-10-22, 23h59 UTC    |
 | Hackathon 1                                                          | 2022-10-23              |
-| Spec 2 BLU deadlines                                                 | 2022-11-19, 23h59 UTC |
+| Spec 2 BLUs submission deadline                                                 | 2022-11-19, 23h59 UTC |
 | Hackathon 2                                                          | 2022-11-20            |
-| Spec 3 BLU deadlines                                                 | 2022-12-17, 23h59 UTC    |
+| Spec 3 BLUs submission deadline                                                 | 2022-12-17, 23h59 UTC    |
 | Hackathon 3                                                          | 2022-12-18              |
-| Spec 4 BLU deadlines                                                 | 2023-02-04 , 23h59 UTC       |
+| Spec 4 BLUs submission deadline                                                 | 2023-02-04 , 23h59 UTC       |
 | Hackathon 4                                                          |    2023-02-05           |
-| Spec 5 BLU deadlines                                                 |  2023-03-04, 23h59 UTC   |
+| Spec 5 BLUs submission deadline                                                 |  2023-03-04, 23h59 UTC   |
 | Hackathon 5                                                          |    2023-03-05           |
-| Spec 6 BLU deadlines                                                 | 2023-04-01, 23h59 UTC   |
+| Spec 6 BLUs submission deadline                                                 | 2023-04-01, 23h59 UTC   |
 | Hackathon 6                                                          |   2023-04-02          |
 | Capstone Kick off                                                    |     2023-04-03         |
 | Capstone Clarification email                                       |       2023-04-09       |

--- a/docs/_docs/Starters Academy (LDSSA)/05-Capstone-Project.md
+++ b/docs/_docs/Starters Academy (LDSSA)/05-Capstone-Project.md
@@ -120,15 +120,16 @@ The capstone will automatically be considered a fail if:
 
 ### Calendar
 
-Description |  Date | 
--------------|-------------|
-Kick off |  17th January 2022 | 
-Trial round of requests |  4th or 5th February 2022 |  
-Deadline report 1 and app launched |  6th February 2022, 23h59 UTC  |
-First round of requests  |  7th February 2022 at 00h01UTC to 14th February 2022 at 23h59 UTC  |
-Comments to report 1 made by instructors  |  14th February 2022 23h59 UTC  |
-Deadline report 2 + redeploy + address comments to report 1 |  6th March 2022, 23h59 UTC  |
-Second round of requests |  7th March 2022 at 00h01UTC to 14th March 2022 at 23h59 UTC  |
-Comments to report 2 made by instructors  |  13th March 2022, 23h59 UTC  |
-Deadline address comments to report 2  |  20th March 2022, 23h59 UTC  |
-Graduates announced  |  31st March 2022  |
+| Description                                                 | Date                                                             |
+|-------------------------------------------------------------|------------------------------------------------------------------|
+| Kick off                                                    |  2023-04-03                                               |
+| Capstone Clarification email                                       |  2023-04-09       |
+| Trial round of requests                                     |          2023-04-23                               |
+| Deadline Provisory report 1 and app launched                          | 2023-04-30 , 23h59 UTC                                    |
+| First round of requests                                     | 2023-05-01 to 2023-05-07 |
+| Comments to report 1 made by instructors                    | 2023-05-07 23h59 UTC                                     |
+| Deadline report 2 + redeploy + address comments to report 1 |  2023-05-28, 23h59 UTC                                       |
+| Second round of requests                                    |   2023-05-29 to 2023-06-02     |
+| Comments to report 2 made by instructors                    | 2023-06-04 , 23h59 UTC                                       |
+| Deadline address comments to report 2                       | 2023-06-11, 23h59 UTC                                       |
+| Graduates announced                                         | 2023-06-19                                                |

--- a/docs/_docs/Volunteers/Volunteer-Onboarding.md
+++ b/docs/_docs/Volunteers/Volunteer-Onboarding.md
@@ -34,7 +34,7 @@ Make sure you check all items on the checklist below before anything else. If yo
    5. ⬜️ Subscribe to these Google calendars (after logging in with your new staff account):
       - [LDSSA Instructors Calendar](https://calendar.google.com/calendar/embed?src=c_oqhjbe9r3cv5kqkotkes373dog%40group.calendar.google.com&ctz=Europe%2FLisbon) -- our internal deadlines;
       - **(optional)** [LDSSA Birthday Calendar](https://calendar.google.com/calendar/embed?src=c_ki195gmib0aln8b8ipk6cg925c%40group.calendar.google.com&ctz=Europe%2FLisbon);
-      - LDSSA Batch #5 (to be created) -- general deadlines visible to students.
+      - [LDSSA Batch #6](https://calendar.google.com/calendar/embed?src=c_jm13ojnma9kcfc3ehr22qvkq9c%40group.calendar.google.com&ctz=Europe%2FLisbon) -- general deadlines visible to students.
 
       **Note**: To add the calendars, (1) make sure you're logged in to your `@lisbondatascience.org` account on Google, (2) click on each of the calendar links above and click the button <img src="../../images/add_calendar_icon.png" width="12%"/> at the right-bottom of each calendar's webpage.
 


### PR DESCRIPTION
Closes #346 and #348 

## Main changes

- Updated Admissions calendar for 2022
- Updated Academy calendar for 2022/2023
- Updated Capstone calendar for 2023

Google calendar link (under construction): https://calendar.google.com/calendar/embed?src=c_jm13ojnma9kcfc3ehr22qvkq9c%40group.calendar.google.com&ctz=Europe%2FLisbon

Google sheet calendar: https://docs.google.com/spreadsheets/d/1XtpbVT8YHB1mSvJxP8rvWFXqQTdXDPQTiV5or8uzLwI/edit?usp=sharing