### PR TITLE
Update 07-Refund-Policy.md

### DIFF
--- a/docs/_docs/Starters Academy (LDSSA)/07-Refund-Policy.md
+++ b/docs/_docs/Starters Academy (LDSSA)/07-Refund-Policy.md
@@ -6,26 +6,29 @@ order: 7
 
 ## Refund Policy
 
-As students of Lisbon Data Science Starter Academy (LDSSA), you are eligible for a full refund within 1 month after the [Bootcamp start date](https://ldssa.github.io/wiki/Starters%20Academy%20(LDSSA)/01-Starters-Academy-(Course)/#schedule), if you are not happy with our way of Teaching. 
-
+As students of Lisbon Data Science Starter Academy (LDSSA), you are eligible for a full refund up to 14 days after the [Bootcamp start date](https://ldssa.github.io/wiki/Starters%20Academy%20(LDSSA)/01-Starters-Academy-(Course)/#schedule). Now you might be wondering:
 
 Now you might be wondering:
 
-**Why the deadline of one month?**
+**Why the deadline of 14 days?**
 
-Within one month from the Bootcamp start date, you will get to attend both the Bootcamp and the first Hackathon. What you experience during the first month will be highly similar to the rest of the Academy. Hence, we believe the current deadline is enough time to get a good view of our [Teaching styles](https://ldssa.github.io/wiki/About%20us/Teaching-Philosophy/), and how it would be like to study until the very last day.
+Within the first two weeks of the LDSSA, you will get to attend the Bootcamp and start working on the first learning units. What you experience during this time will be highly similar to the rest of the Academy. Hence, we believe the current deadline is enough time to get a good view of our [Teaching styles](https://ldssa.github.io/wiki/About%20us/Teaching-Philosophy/).
 
-**Why no partial refund?**
+**Why no partial refund after the 14 days?**
 
 The refund policy was created for you to evaluate whether LDSSA would be the right fit. It is not intended to accommodate any changes in personal schedule or availability, or not being comfortable with the required workload. Hence, we will not offer any partial refund after the deadline has passed.
 
+**What if I get sick?**
+
+In case of sickness, or other unforeseen events, cases will be evaluated on an ad hoc manner. To request your refund please send an email studentsuccess@lisbondatascience.org including your justification, a note for your medical doctor and any other type of supporting information. Within 30 days, you will receive an answer on whether your refund has been accepted or not. 
 
 ## Refund Process
 
-If the refund deadline has not passed, you can ask for a refund by sending an email to `info@lisbondatascience.org`. Within 30 days, you will receive an answer on whether your refund has been accepted or not. 
+If the refund deadline has not passed, you can ask for a refund by sending an email to studentsuccess@lisbondatascience.org. Within 30 days, you will receive an answer on whether your refund has been accepted or not. 
 
 In the email, please make sure that you include the following information:
 * Full Name
-* Proof of payment
+* Proof of payments
 * Recipient IBAN (The refund can only be made via the same IBAN used to make the payment) 
-* Reason for refund - Please explain why you would like to drop out. Let us know if there’s anything we can improve and make it a better learning experience for you.
+* Reason for refund (Optional) - Although not required within the 14 days deadline, please let us know why you would like to drop out, if there’s anything we can improve and how we can make it a better learning experience for you.
+


### PR DESCRIPTION
This PR closes #302 

The refund policy has been updated to abide by consumer rights (DL n.º 24/2014, de 14 de Fevereiro CONTRATOS CELEBRADOS À DISTÂNCIA E FORA DO ESTABELECIMENTO COMERCIAL ([https://www.pgdlisboa.pt/leis/lei_mostra_articulado.php?artigo_id=2062A0012&nid=2062&tabela=leis&pagina=1&ficha=1&so_miolo=&nversao=](https://www.google.com/url?q=https://www.pgdlisboa.pt/leis/lei_mostra_articulado.php?artigo_id%3D2062A0012%26nid%3D2062%26tabela%3Dleis%26pagina%3D1%26ficha%3D1%26so_miolo%3D%26nversao%3D&sa=D&source=docs&ust=1654727079345039&usg=AOvVaw1c_sFSE9Jd5Z7azGbs1C-2))) and to reflect our new policy on refunds for batch 6.

## Main changes

- Direct refunds can be asked within 14 days of the BootCamp starting date (this year the 1st of October)
- Refunds can be asked for very valid reasons such as medical conditions, as long as properly justified. They will be evaluated ad hoc